### PR TITLE
[WIP]: Use `StreamExt::split` and allow options to be set on `SocketBuilder`

### DIFF
--- a/examples/client_worker.rs
+++ b/examples/client_worker.rs
@@ -70,8 +70,8 @@ async fn worker(ctx: Rc<Context>, worker_id: u64, backend: String) -> Result<(),
 
 /// Simulates zmq::proxy using asynchronous sockets.
 async fn proxy(ctx: Rc<Context>, frontend: String, backend: String) -> tmq::Result<()> {
-    let (mut router_rx, mut router_tx) = router(&ctx).bind(&frontend)?.split();
-    let (mut dealer_rx, mut dealer_tx) = dealer(&ctx).bind(&backend)?.split();
+    let (mut router_tx, mut router_rx) = router(&ctx).bind(&frontend)?.split();
+    let (mut dealer_tx, mut dealer_rx) = dealer(&ctx).bind(&backend)?.split();
 
     let mut frontend_fut = router_rx.next();
     let mut backend_fut = dealer_rx.next();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -87,18 +87,6 @@ macro_rules! impl_as_socket {
     };
 }
 
-macro_rules! impl_split {
-    ($type: ty, $field: ident) => {
-        impl $type {
-            #[inline]
-            /// Implements a `split` method for the Socket wrapping an inner `SenderReceiver`.
-            pub fn split(self) -> ($crate::SharedReceiver, $crate::SharedSender) {
-                self.$field.split()
-            }
-        }
-    };
-}
-
 macro_rules! impl_buffered {
     ($type: ty, $field: ident) => {
         impl $type {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -50,54 +50,13 @@ pub trait AsZmqSocket {
 /// Trait which defines configuration functions for ZMQ sockets.
 ///
 /// See ZMQ documentation for more info: [http://api.zeromq.org/4-2:zmq-setsockopt](http://api.zeromq.org/4-2:zmq-setsockopt)
+///
+/// Some socket options need to be set before bind/connect via the [`SocketBuilder`](struct.SocketBuilder.html) methods
 pub trait SocketExt {
-    /// Configure the socket for [monitoring](http://api.zeromq.org/4-2:zmq-socket-monitor)
-    fn monitor(&self, monitor_endpoint: &str, events: i32) -> Result<()>;
-
-    /// Accessor for the `ZMQ_IPV6` option.
-    fn is_ipv6(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_IPV6` option.
-    fn set_ipv6(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_IMMEDIATE` option.
-    fn is_immediate(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_IMMEDIATE` option.
-    fn set_immediate(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_PLAIN_SERVER` option.
-    fn is_plain_server(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_PLAIN_SERVER` option.
-    fn set_plain_server(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_CONFLATE` option.
-    fn is_conflate(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_CONFLATE` option.
-    fn set_conflate(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_PROBE_ROUTER` option.
-    fn is_probe_router(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_PROBE_ROUTER` option.
-    fn set_probe_router(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_CURVE_SERVER` option.
-    fn is_curve_server(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_CURVE_SERVER` option.
-    fn set_curve_server(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_GSSAPI_SERVER` option.
-    fn is_gssapi_server(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_GSSAPI_SERVER` option.
-    fn set_gssapi_server(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_GSSAPI_PLAINTEXT` option.
-    fn is_gssapi_plaintext(&self) -> Result<bool>;
-    /// Setter for the `ZMQ_GSSAPI_PLAINTEXT` option.
-    fn set_gssapi_plaintext(&self, value: bool) -> Result<()>;
-
-    /// Accessor for the `ZMQ_MAXMSGSIZE` option.
-    fn get_maxmsgsize(&self) -> Result<i64>;
-    /// Setter for the `ZMQ_MAXMSGSIZE` option.
-    fn set_maxmsgsize(&self, value: i64) -> Result<()>;
+    /// Accessor for the `ZMQ_LINGER` option.
+    fn get_linger(&self) -> Result<i32>;
+    /// Setter for the `ZMQ_LINGER` option.
+    fn set_linger(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_SNDHWM` option.
     fn get_sndhwm(&self) -> Result<i32>;
@@ -109,60 +68,64 @@ pub trait SocketExt {
     /// Setter for the `ZMQ_RCVHWM` option.
     fn set_rcvhwm(&self, value: i32) -> Result<()>;
 
+    /// Accessor for the `ZMQ_PROBE_ROUTER` option.
+    fn is_probe_router(&self) -> Result<bool>;
+    /// Setter for the `ZMQ_PROBE_ROUTER` option.
+    fn set_probe_router(&self, value: bool) -> Result<()>;
+
+    /// Accessor for the `ZMQ_IPV6` option.
+    fn is_ipv6(&self) -> Result<bool>;
+
+    /// Accessor for the `ZMQ_IMMEDIATE` option.
+    fn is_immediate(&self) -> Result<bool>;
+
+    /// Accessor for the `ZMQ_PLAIN_SERVER` option.
+    fn is_plain_server(&self) -> Result<bool>;
+
+    /// Accessor for the `ZMQ_CONFLATE` option.
+    fn is_conflate(&self) -> Result<bool>;
+
+    /// Accessor for the `ZMQ_CURVE_SERVER` option.
+    fn is_curve_server(&self) -> Result<bool>;
+
+    /// Accessor for the `ZMQ_GSSAPI_SERVER` option.
+    fn is_gssapi_server(&self) -> Result<bool>;
+
+    /// Accessor for the `ZMQ_GSSAPI_PLAINTEXT` option.
+    fn is_gssapi_plaintext(&self) -> Result<bool>;
+
+    /// Accessor for the `ZMQ_MAXMSGSIZE` option.
+    fn get_maxmsgsize(&self) -> Result<i64>;
+
     /// Accessor for the `ZMQ_AFFINITY` option.
     fn get_affinity(&self) -> Result<u64>;
-    /// Setter for the `ZMQ_AFFINITY` option.
-    fn set_affinity(&self, value: u64) -> Result<()>;
 
     /// Accessor for the `ZMQ_RATE` option.
     fn get_rate(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_RATE` option.
-    fn set_rate(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_RECOVERY_IVL` option.
     fn get_recovery_ivl(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_RECOVERY_IVL` option.
-    fn set_recovery_ivl(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_SNDBUF` option.
     fn get_sndbuf(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_SNDBUF` option.
-    fn set_sndbuf(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_RCVBUF` option.
     fn get_rcvbuf(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_RCVBUF` option.
-    fn set_rcvbuf(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_TOS` option.
     fn get_tos(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_TOS` option.
-    fn set_tos(&self, value: i32) -> Result<()>;
-
-    /// Accessor for the `ZMQ_LINGER` option.
-    fn get_linger(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_LINGER` option.
-    fn set_linger(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_RECONNECT_IVL` option.
     fn get_reconnect_ivl(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_RECONNECT_IVL` option.
-    fn set_reconnect_ivl(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_RECONNECT_IVL_MAX` option.
     fn get_reconnect_ivl_max(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_RECONNECT_IVL_MAX` option.
-    fn set_reconnect_ivl_max(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_BACKLOG` option.
     fn get_backlog(&self) -> Result<i32>;
-    /// Setter for the `ZMQ_BACKLOG` option.
-    fn set_backlog(&self, value: i32) -> Result<()>;
 
     /// Accessor for the `ZMQ_IDENTITY` option.
     fn get_identity(&self) -> Result<Vec<u8>>;
-    /// Setter for the `ZMQ_IDENTITY` option.
-    fn set_identity(&self, value: &[u8]) -> Result<()>;
 }
 
 macro_rules! getter {
@@ -183,38 +146,24 @@ macro_rules! setter {
 }
 
 impl<T: AsZmqSocket> SocketExt for T {
-    fn monitor(&self, monitor_endpoint: &str, events: i32) -> Result<()> {
-        self.get_socket()
-            .monitor(monitor_endpoint, events)
-            .map_err(|e| e.into())
-    }
-
     getter!(is_ipv6, bool);
-    setter!(set_ipv6, bool);
 
     getter!(is_immediate, bool);
-    setter!(set_immediate, bool);
 
     getter!(is_plain_server, bool);
-    setter!(set_plain_server, bool);
 
     getter!(is_conflate, bool);
-    setter!(set_conflate, bool);
 
     getter!(is_probe_router, bool);
     setter!(set_probe_router, bool);
 
     getter!(is_curve_server, bool);
-    setter!(set_curve_server, bool);
 
     getter!(is_gssapi_server, bool);
-    setter!(set_gssapi_server, bool);
 
     getter!(is_gssapi_plaintext, bool);
-    setter!(set_gssapi_plaintext, bool);
 
     getter!(get_maxmsgsize, i64);
-    setter!(set_maxmsgsize, i64);
 
     getter!(get_sndhwm, i32);
     setter!(set_sndhwm, i32);
@@ -223,35 +172,25 @@ impl<T: AsZmqSocket> SocketExt for T {
     setter!(set_rcvhwm, i32);
 
     getter!(get_affinity, u64);
-    setter!(set_affinity, u64);
 
     getter!(get_rate, i32);
-    setter!(set_rate, i32);
 
     getter!(get_recovery_ivl, i32);
-    setter!(set_recovery_ivl, i32);
 
     getter!(get_sndbuf, i32);
-    setter!(set_sndbuf, i32);
 
     getter!(get_rcvbuf, i32);
-    setter!(set_rcvbuf, i32);
 
     getter!(get_tos, i32);
-    setter!(set_tos, i32);
 
     getter!(get_linger, i32);
     setter!(set_linger, i32);
 
     getter!(get_reconnect_ivl, i32);
-    setter!(set_reconnect_ivl, i32);
 
     getter!(get_reconnect_ivl_max, i32);
-    setter!(set_reconnect_ivl_max, i32);
 
     getter!(get_backlog, i32);
-    setter!(set_backlog, i32);
 
     getter!(get_identity, Vec<u8>);
-    setter!(set_identity, &[u8]);
 }

--- a/src/socket_builder.rs
+++ b/src/socket_builder.rs
@@ -1,40 +1,165 @@
-use crate::FromZmqSocket;
+use crate::{FromZmqSocket, TmqError};
 use zmq::{Context, SocketType};
 
-/// Builder which provides [`bind`] and [`connect`] methods to build a corresponding ZMQ socket.
+macro_rules! setter {
+    ($name: ident, $type: ty, $doc: expr) => {
+        #[doc=$doc]
+        pub fn $name(mut self, value: $type) -> Self {
+
+            if self.error.is_some() {
+                return self
+            }
+
+            if let Some(ref socket) =  self.socket {
+
+                if let Err(err) = socket.$name(value) {
+                    self.error = Some(err.into());
+                }
+
+            }
+
+            self
+
+        }
+    }
+}
+
+/// Builder which provides [`bind`] and [`connect`] methods to build a corresponding ZMQ socket as per the standard functions
+///
+/// You can use the standard functions from the crate to create a builder
+///
+/// Use the `set_` functions to set socket options before binding/connecting
+///
+/// See ZMQ documentation for more info on what these options do: [http://api.zeromq.org/4-2:zmq-setsockopt](http://api.zeromq.org/4-2:zmq-setsockopt)
 ///
 /// [`bind`]: struct.SocketBuilder.html#method.bind
 /// [`connect`]: struct.SocketBuilder.html#method.connect
-pub struct SocketBuilder<'a, T> {
-    context: &'a ::zmq::Context,
-    socket_type: ::zmq::SocketType,
+pub struct SocketBuilder<T> {
+    socket: Option<::zmq::Socket>,
+    error: Option<TmqError>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T> SocketBuilder<'a, T>
+impl<T> SocketBuilder<T>
 where
     T: FromZmqSocket<T>,
 {
     #[doc(hidden)]
-    pub(crate) fn new(context: &'a Context, socket_type: SocketType) -> Self {
+    pub(crate) fn new(context: &Context, socket_type: SocketType) -> Self {
+        let mut socket = None;
+
+        //Defer the Error to make things easier for consumers
+        let mut error = None;
+
+        match context.socket(socket_type) {
+            Ok(sock) => socket = Some(sock),
+            Err(err) => error = Some(err.into()),
+        };
+
         Self {
-            context,
-            socket_type,
+            socket,
+            error,
             _phantom: Default::default(),
         }
     }
 
     /// Connect to a ZMQ endpoint at the given address.
     pub fn connect(self, endpoint: &str) -> crate::Result<T> {
-        let socket = self.context.socket(self.socket_type)?;
+        if let Some(err) = self.error {
+            return Err(err);
+        }
+
+        let socket = self.socket.unwrap();
         socket.connect(endpoint)?;
         T::from_zmq_socket(socket)
     }
 
     /// Bind to a ZMQ endpoint at the given address.
     pub fn bind(self, endpoint: &str) -> crate::Result<T> {
-        let socket = self.context.socket(self.socket_type)?;
+        if let Some(err) = self.error {
+            return Err(err);
+        }
+
+        let socket = self.socket.unwrap();
         socket.bind(endpoint)?;
         T::from_zmq_socket(socket)
     }
+
+    /// Configure the socket for [monitoring](http://api.zeromq.org/4-2:zmq-socket-monitor)
+    pub fn monitor(mut self, monitor_endpoint: &str, events: i32) -> Self {
+        if self.error.is_some() {
+            return self;
+        }
+
+        if let Some(ref socket) = self.socket {
+            if let Err(err) = socket.monitor(monitor_endpoint, events) {
+                self.error = Some(err.into());
+            }
+        }
+
+        self
+    }
+
+    setter!(set_ipv6, bool, "Setter for the `ZMQ_IPV6` option.");
+    setter!(
+        set_immediate,
+        bool,
+        "Setter for the `ZMQ_IMMEDIATE` option."
+    );
+    setter!(
+        set_plain_server,
+        bool,
+        "Setter for the `ZMQ_PLAIN_SERVER` option."
+    );
+    setter!(set_conflate, bool, "Setter for the `ZMQ_CONFLATE` option.");
+    setter!(
+        set_probe_router,
+        bool,
+        "Setter for the `ZMQ_PROBE_ROUTER` option."
+    );
+    setter!(
+        set_curve_server,
+        bool,
+        "Setter for the `ZMQ_CURVE_SERVER` option."
+    );
+    setter!(
+        set_gssapi_server,
+        bool,
+        "Setter for the `ZMQ_GSSAPI_SERVER` option."
+    );
+    setter!(
+        set_gssapi_plaintext,
+        bool,
+        "Setter for the `ZMQ_GSSAPI_PLAINTEXT` option."
+    );
+    setter!(
+        set_maxmsgsize,
+        i64,
+        "Setter for the `ZMQ_MAXMSGSIZE` option."
+    );
+    setter!(set_sndhwm, i32, "Setter for the `ZMQ_SNDHWM` option.");
+    setter!(set_rcvhwm, i32, "Setter for the `ZMQ_RCVHWM` option.");
+    setter!(set_affinity, u64, "Setter for the `ZMQ_AFFINITY` option.");
+    setter!(set_rate, i32, "Setter for the `ZMQ_RATE` option.");
+    setter!(
+        set_recovery_ivl,
+        i32,
+        "Setter for the `ZMQ_RECOVERY_IVL` option."
+    );
+    setter!(set_sndbuf, i32, "Setter for the `ZMQ_SNDBUF` option.");
+    setter!(set_rcvbuf, i32, "Setter for the `ZMQ_RCVBUF` option.");
+    setter!(set_tos, i32, "Setter for the `ZMQ_TOS` option.");
+    setter!(set_linger, i32, "Setter for the `ZMQ_LINGER` option.");
+    setter!(
+        set_reconnect_ivl,
+        i32,
+        "Setter for the `ZMQ_RECONNECT_IVL` option."
+    );
+    setter!(
+        set_reconnect_ivl_max,
+        i32,
+        "Setter for the `ZMQ_RECONNECT_IVL_MAX` option."
+    );
+    setter!(set_backlog, i32, "Setter for the `ZMQ_BACKLOG` option.");
+    setter!(set_identity, &[u8], "Setter for the `ZMQ_IDENTITY` option.");
 }

--- a/src/socket_types/dealer.rs
+++ b/src/socket_types/dealer.rs
@@ -23,4 +23,3 @@ impl FromZmqSocket<Dealer> for Dealer {
 impl_wrapper!(Dealer, SenderReceiver, inner);
 impl_wrapper_sink!(Dealer, inner);
 impl_wrapper_stream!(Dealer, inner);
-impl_split!(Dealer, inner);

--- a/src/socket_types/router.rs
+++ b/src/socket_types/router.rs
@@ -26,7 +26,6 @@ impl FromZmqSocket<Router> for Router {
 impl_wrapper!(Router, SenderReceiver, inner);
 impl_wrapper_sink!(Router, inner);
 impl_wrapper_stream!(Router, inner);
-impl_split!(Router, inner);
 
 impl Router {
     /// Accessor for the `ZMQ_ROUTER_MANDATORY` option.

--- a/tests/dealer.rs
+++ b/tests/dealer.rs
@@ -88,15 +88,6 @@ async fn receive_hammer() -> Result<()> {
 }
 
 #[tokio::test]
-async fn receive_buffered_hammer() -> Result<()> {
-    let address = generate_tcp_address();
-    let ctx = Context::new();
-    let sock = dealer(&ctx).bind(&address)?;
-    let (rx, _) = sock.split();
-    hammer_receive(rx.buffered(1024), address, SocketType::DEALER).await
-}
-
-#[tokio::test]
 async fn proxy_sequence() -> Result<()> {
     let address = generate_tcp_address();
     let ctx = Context::new();
@@ -164,7 +155,7 @@ async fn proxy_interleaved() -> Result<()> {
 async fn split_echo() -> Result<()> {
     let address = generate_tcp_address();
     let ctx = Context::new();
-    let (rx, tx) = dealer(&ctx).bind(&address)?.split();
+    let (tx, rx) = dealer(&ctx).bind(&address)?.split();
     let count = 10;
 
     let thread = spawn(move || {
@@ -198,7 +189,7 @@ async fn split_echo() -> Result<()> {
 async fn split_send_all() -> Result<()> {
     let address = generate_tcp_address();
     let ctx = Context::new();
-    let (_, mut tx) = dealer(&ctx).connect(&address)?.split();
+    let (mut tx, _) = dealer(&ctx).connect(&address)?.split();
 
     let count = 10_000;
     let thread = spawn(move || {


### PR DESCRIPTION
The `split` method in `comm` does not appear to be `Send` and so fails
when trying to use `tokio::spawn`.  This is a little cumbersome to interact with the greater tokio ecosystem.

The standard `StreamExt::split` method from futures works fine though but does obviously require some nuancing

Some socket options need to be set before bind/connect, for instance, the `identity` option, so the
`SocketBuilder` should allow them to be set beforehand & should not be settable after connect/bind.

Some trickery is used to defer errors until connect/bind are called, but means you don't need to check errors and can chain the builder.

```rust
 let mut socket = dealer(&Context::new())
        .set_identity(b"test")
        .connect("tcp://127.0.0.1:8888")?;
```