### PR TITLE
expose feature "zmq/vendored"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/cetra3/tmq"
 readme = "README.md"
 edition = "2018"
 
+[features]
+zmq-vendored = ["zmq/vendored"]
+
 [dependencies]
 bytes = "0.5"
 futures = "0.3"


### PR DESCRIPTION
Unfortunately, I am not able to build rust-zmq on the Debian servers of my company because it requires libzmq >= 4.1. Thankfully, rust-zmq has the feature to use a vendored build. This pull request enables us to use this feature also in tmq.
