### PR TITLE
Set HWM before connect/bind in tests

### DIFF
--- a/tests/pair.rs
+++ b/tests/pair.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Barrier},
     thread::spawn,
 };
-use tmq::{pair, Result, SocketExt};
+use tmq::{pair, Result};
 use utils::{check_receive_multiparts, generate_tcp_address, hammer_receive, sync_send_multiparts};
 
 mod utils;
@@ -77,8 +77,7 @@ async fn receive_delayed() -> Result<()> {
     barrier.wait();
 
     let ctx = Context::new();
-    let mut sock = pair(&ctx).bind(&address_recv)?;
-    sock.set_rcvhwm(1)?;
+    let mut sock = pair(&ctx).set_rcvhwm(1).bind(&address_recv)?;
 
     for _ in 0..3 {
         sock.next().await.unwrap()?;

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Barrier},
     thread::spawn,
 };
-use tmq::{pull, Result, SocketExt};
+use tmq::{pull, Result};
 use utils::{check_receive_multiparts, generate_tcp_address, hammer_receive, sync_send_multiparts};
 
 mod utils;
@@ -85,8 +85,7 @@ async fn receive_delayed() -> Result<()> {
     barrier.wait();
 
     let ctx = Context::new();
-    let mut sock = pull(&ctx).bind(&address_recv)?;
-    sock.set_rcvhwm(1)?;
+    let mut sock = pull(&ctx).set_rcvhwm(1).bind(&address_recv)?;
 
     for _ in 0..3 {
         sock.next().await.unwrap()?;

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -2,7 +2,7 @@ use zmq::{Context, SocketType};
 
 use futures::SinkExt;
 use std::{thread::spawn, time::Duration};
-use tmq::{push, Result, SocketExt};
+use tmq::{push, Result};
 use tokio::time::timeout;
 use utils::{
     generate_tcp_address, msg, send_multipart_repeated, send_multiparts,
@@ -84,10 +84,9 @@ async fn send_hammer() -> Result<()> {
 async fn send_delayed() -> Result<()> {
     let address = generate_tcp_address();
     let ctx = Context::new();
-    let mut sock = push(&ctx).connect(&address)?;
 
     // set send high water mark to a single message
-    sock.set_sndhwm(1).unwrap();
+    let mut sock = push(&ctx).set_sndhwm(1).connect(&address)?;
 
     // send a single message, now the send buffer should be full
     sock.send(vec![msg(b"hello")]).await?;


### PR DESCRIPTION
SNDHWM/RCVHWM needs to be set before connect/bind in older version of
ZMQ (4.1). This fixes the failure in the test `send_delayed`.