### PR TITLE
added struct RequestReply 

### DIFF
--- a/src/socket_types/request_reply.rs
+++ b/src/socket_types/request_reply.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use crate::{poll::ZmqPoller, AsZmqSocket, FromZmqSocket, Multipart, SocketBuilder};
+use crate::{poll::ZmqPoller, FromZmqSocket, Multipart, SocketBuilder};
 use zmq::{self, Context as ZmqContext};
 
 /// Create a builder for a REQ socket


### PR DESCRIPTION
allows send()  and recv() to be cancel safe : they both take mutable references to the struct

in the case of recv() being used inside a tokio::select! for example


It should probably be specified that this isn't as safe as the RequestSender / RequestReceiver way as you could try to send a multipart before receiving data in the case of the receiver and vice versa.