### PR TITLE
remove redundant import that current rust nightly complains about

### DIFF
--- a/src/socket_types/dealer.rs
+++ b/src/socket_types/dealer.rs
@@ -1,4 +1,4 @@
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 use crate::{comm::SenderReceiver, poll::ZmqPoller, FromZmqSocket, SocketBuilder};
 

--- a/src/socket_types/pair.rs
+++ b/src/socket_types/pair.rs
@@ -1,4 +1,4 @@
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 use crate::{comm::SenderReceiver, poll::ZmqPoller, FromZmqSocket, SocketBuilder};
 

--- a/src/socket_types/publish.rs
+++ b/src/socket_types/publish.rs
@@ -1,4 +1,4 @@
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 use crate::{poll::ZmqPoller, FromZmqSocket, Sender, SocketBuilder};
 

--- a/src/socket_types/pull.rs
+++ b/src/socket_types/pull.rs
@@ -1,4 +1,4 @@
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 use crate::{comm::Receiver, poll::ZmqPoller, FromZmqSocket, SocketBuilder};
 

--- a/src/socket_types/push.rs
+++ b/src/socket_types/push.rs
@@ -1,4 +1,4 @@
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 use crate::{comm::Sender, poll::ZmqPoller, FromZmqSocket, SocketBuilder};
 

--- a/src/socket_types/request_reply.rs
+++ b/src/socket_types/request_reply.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 
 use crate::{poll::ZmqPoller, FromZmqSocket, Multipart, SocketBuilder};
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 /// Create a builder for a REQ socket
 pub fn request(context: &ZmqContext) -> SocketBuilder<RequestSender> {

--- a/src/socket_types/router.rs
+++ b/src/socket_types/router.rs
@@ -1,4 +1,4 @@
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 use crate::{
     comm::SenderReceiver, poll::ZmqPoller, socket::AsZmqSocket, FromZmqSocket, Result,

--- a/src/socket_types/subscribe.rs
+++ b/src/socket_types/subscribe.rs
@@ -1,4 +1,4 @@
-use zmq::{self, Context as ZmqContext};
+use zmq::Context as ZmqContext;
 
 use crate::{poll::ZmqPoller, socket::AsZmqSocket, FromZmqSocket, Receiver, SocketBuilder};
 


### PR DESCRIPTION
Current rust nightly complains about some redundant imports, so just remove these imports.
I've checked that these imports are not needed, even on rust stable.

```
$ rustc --version
rustc 1.79.0-nightly (ab5bda1aa 2024-04-08)
$ cargo check
    Checking tmq v0.4.0 (/home/aurel/devel/embedded/tmq)
warning: the item `zmq` is imported redundantly
 --> src/socket_types/dealer.rs:1:11
  |
1 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude
  |
  = note: `#[warn(unused_imports)]` on by default

warning: the item `zmq` is imported redundantly
 --> src/socket_types/pair.rs:1:11
  |
1 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude

warning: the item `zmq` is imported redundantly
 --> src/socket_types/publish.rs:1:11
  |
1 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude

warning: the item `zmq` is imported redundantly
 --> src/socket_types/pull.rs:1:11
  |
1 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude

warning: the item `zmq` is imported redundantly
 --> src/socket_types/push.rs:1:11
  |
1 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude

warning: the item `zmq` is imported redundantly
 --> src/socket_types/request_reply.rs:4:11
  |
4 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude

warning: the item `zmq` is imported redundantly
 --> src/socket_types/router.rs:1:11
  |
1 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude

warning: the item `zmq` is imported redundantly
 --> src/socket_types/subscribe.rs:1:11
  |
1 | use zmq::{self, Context as ZmqContext};
  |           ^^^^ the item `zmq` is already defined by prelude

warning: `tmq` (lib) generated 8 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.18s
```