### PR TITLE
Add plain_username, password and zap_domain socket options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "tmq"
-version = "0.4.0"
-authors = ["cetra3 <cetra3@hotmail.com>", "skrap <jonah@petri.us>", "kobzol <berykubik@gmail.com>", "YushiOMOTE <yushiomote@gmail.com>"]
+version = "0.5.0"
+authors = ["cetra3 <cetra3@hotmail.com>", "skrap <jonah@petri.us>", "kobzol <berykubik@gmail.com>", "YushiOMOTE <yushiomote@gmail.com>", "iddm <fx@thefx.co>"]
 license = "MIT/Apache-2.0"
 description = "ZeroMQ bindings for Tokio"
 repository = "https://github.com/cetra3/tmq"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-tokio = { version = "1.29", features = ["net"] }
+tokio = { version = "1", features = ["net"] }
 zmq = "0.10"
 log = "0.4"
 thiserror = "1"

--- a/src/socket_builder.rs
+++ b/src/socket_builder.rs
@@ -107,6 +107,21 @@ where
         bool,
         "Setter for the `ZMQ_PLAIN_SERVER` option."
     );
+    setter!(
+        set_plain_username,
+        Option<&str>,
+        "Setter for the `ZMQ_PLAIN_USERNAME` option."
+    );
+    setter!(
+        set_plain_password,
+        Option<&str>,
+        "Setter for the `ZMQ_PLAIN_PASSWORD` option."
+    );
+    setter!(
+        set_zap_domain,
+        &str,
+        "Setter for the `ZMQ_ZAP_DOMAIN` option."
+    );
     setter!(set_conflate, bool, "Setter for the `ZMQ_CONFLATE` option.");
     setter!(
         set_probe_router,


### PR DESCRIPTION
Also changes the tokio version to be "1", and rust edition to 2021.